### PR TITLE
Make functions pure

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,17 +87,49 @@ expired.on(headers)
 
 ## API
 
-### expired(headers)
+### expired(headers, [date])
 
 Returns a boolean relating to whether the resource has expired or not. `true` means it's expired, `false` means it's fresh.
 
-### expired.in(headers)
+#### headers
+
+Type: `string`, `object`<br>
+
+String or object containing HTTP headers.
+
+#### date
+
+Type: `Date`<br>
+Default: `new Date()`
+
+Optional `Date` object to compare against.
+
+### expired.in(headers, [date])
 
 Returns the amount of milliseconds from the current date until the resource will expire. If the resource has already expired it will return a negative integer.
+
+#### headers
+
+Type: `string`, `object`<br>
+
+String or object containing HTTP headers.
+
+#### date
+
+Type: `Date`<br>
+Default: `new Date()`
+
+Optional `Date` object to compare against.
 
 ### expired.on(headers)
 
 Returns a JavaScript `Date` object for the date the resource will expire.
+
+#### headers
+
+Type: `string`, `object`<br>
+
+String or object containing HTTP headers.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ expired(headers)
 // false
 ```
 
+## Pure Usage
+
 You can make the functions pure by passing in a JavaScript `Date` object to compare to instead of depending on `new Date()`. This isn't necessary for `expired.on` as it doesn't compare dates and is already pure.
 
 The following are all pure functions:

--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ expired(headers)
 // false
 ```
 
+You can make the functions pure by passing in a JavaScript `Date` object to compare to instead of depending on `new Date()`. This isn't necessary for `expired.on` as it doesn't compare dates and is already pure.
+
+The following are all pure functions:
+
+```js
+const headers = `...`;
+const date = new Date();
+
+expired(headers, date)
+expired.in(headers, date)
+expired.on(headers)
+```
+
 ## API
 
 ### expired(headers)

--- a/README.md
+++ b/README.md
@@ -93,45 +93,13 @@ expired.on(headers)
 
 Returns a boolean relating to whether the resource has expired or not. `true` means it's expired, `false` means it's fresh.
 
-#### headers
-
-Type: `string`, `object`<br>
-
-String or object containing HTTP headers.
-
-#### date
-
-Type: `Date`<br>
-Default: `new Date()`
-
-Optional `Date` object to compare against.
-
 ### expired.in(headers, [date])
 
 Returns the amount of milliseconds from the current date until the resource will expire. If the resource has already expired it will return a negative integer.
 
-#### headers
-
-Type: `string`, `object`<br>
-
-String or object containing HTTP headers.
-
-#### date
-
-Type: `Date`<br>
-Default: `new Date()`
-
-Optional `Date` object to compare against.
-
 ### expired.on(headers)
 
 Returns a JavaScript `Date` object for the date the resource will expire.
-
-#### headers
-
-Type: `string`, `object`<br>
-
-String or object containing HTTP headers.
 
 ## License
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,13 +14,11 @@ expired.on = headers => {
 	// Parse headers if we got a raw string
 	headers = (typeof headers === 'string') ? parse(headers) : headers;
 
-	let expiredOn = new Date();
+	// Default to Date header
+	let expiredOn = new Date(headers.date);
 
 	// Prefer Cache-Control
 	if (headers['cache-control']) {
-		// Date from headers
-		const originDate = new Date(headers.date);
-
 		// Get max age ms
 		let maxAge = headers['cache-control'].match(/max-age=(\d+)/);
 		maxAge = parseInt(maxAge ? maxAge[1] : 0, 10);
@@ -31,7 +29,7 @@ expired.on = headers => {
 		}
 
 		// Calculate expirey date
-		expiredOn = addSeconds(originDate, maxAge);
+		expiredOn = addSeconds(expiredOn, maxAge);
 
 	// Fall back to Expires if it exists
 	} else if (headers.expires) {

--- a/src/index.js
+++ b/src/index.js
@@ -4,10 +4,10 @@ const addSeconds = require('date-fns/add_seconds');
 const parse = require('parse-headers');
 
 // Returns boolean for whether or not the cache has expired
-const expired = (headers, currentDate = new Date()) => isBefore(expired.on(headers), currentDate);
+const expired = (headers, date = new Date()) => isBefore(expired.on(headers), date);
 
 // Return ms until cache expires
-expired.in = (headers, currentDate = new Date()) => differenceInMilliseconds(expired.on(headers), currentDate);
+expired.in = (headers, date = new Date()) => differenceInMilliseconds(expired.on(headers), date);
 
 // Returns date when cache will expire
 expired.on = headers => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,13 @@
-const isPast = require('date-fns/is_past');
+const isBefore = require('date-fns/is_before');
 const differenceInMilliseconds = require('date-fns/difference_in_milliseconds');
 const addSeconds = require('date-fns/add_seconds');
 const parse = require('parse-headers');
 
 // Returns boolean for whether or not the cache has expired
-const expired = headers => isPast(expired.on(headers));
+const expired = (headers, currentDate = new Date()) => isBefore(expired.on(headers), currentDate);
 
 // Return ms until cache expires
-expired.in = headers => differenceInMilliseconds(expired.on(headers), new Date());
+expired.in = (headers, currentDate = new Date()) => differenceInMilliseconds(expired.on(headers), currentDate);
 
 // Returns date when cache will expire
 expired.on = headers => {

--- a/test/expired.in.js
+++ b/test/expired.in.js
@@ -51,3 +51,15 @@ test('expired.in returns negative ms for stale cache', t => {
 	t.is(expired.in(headers), expiredIn);
 	tk.reset();
 });
+
+test('expired.in accepts currentDate argument', t => {
+	const date = new Date(new Date().toUTCString());
+	const headers = {
+		date: date.toUTCString(),
+		age: 0,
+		'cache-control': 'public, max-age=300'
+	};
+
+	t.is(expired.in(headers, date), 300000);
+	t.is(expired.in(headers, addSeconds(date, 500)), -200000);
+});

--- a/test/expired.js
+++ b/test/expired.js
@@ -1,5 +1,6 @@
 import test from 'ava';
 import subSeconds from 'date-fns/sub_seconds';
+import addSeconds from 'date-fns/add_seconds';
 import expired from '../';
 
 test('expired is a function', t => {
@@ -24,4 +25,16 @@ test('expired returns true for stale cache', t => {
 	};
 
 	t.true(expired(headers));
+});
+
+test('expired accepts currentDate argument', t => {
+	const date = new Date();
+	const headers = {
+		date: date.toUTCString(),
+		age: 0,
+		'cache-control': 'public, max-age=300'
+	};
+
+	t.false(expired(headers, date));
+	t.true(expired(headers, addSeconds(date, 500)));
 });


### PR DESCRIPTION
Instead of using `new Date()` to compare to the current time allow a JavaScript `Date` object to be passed in.

Resolves https://github.com/lukechilds/expired/issues/6